### PR TITLE
Implement ghcr Image Upload

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -5,21 +5,32 @@ name: Build and Deploy to Staging server
 
 on:
   push:
-    branches: [ master ]
+    branches: [ ghcr-test ]
   pull_request:
-    branches: [ master ]
+    branches: [ ghcr-test ]
+
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  REMOTE_PATH: /opt/dockerfiles/radio
+  GHCR_USER: splayfery
+  TAGS: latest
 
 jobs:
-  build-and-deploy:
+  build-and-publish:
 
     runs-on: ubuntu-latest
     
     permissions:
       contents: read
       packages: write
+      attestations: write
+      id-token: write
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout Repository
+      uses: actions/checkout@v4
        
     - name: Set up Coretto 21
       uses: actions/setup-java@v3
@@ -42,6 +53,66 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build --parallel --no-daemon --configuration-cache
 
+    - name: Set up QEMU (for ARM emulation)
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        install: true
+        driver: docker-container
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Cleanup old latest images in GHCR
+      uses: actions/delete-package-versions@v5
+      with:
+        package-name: radio
+        package-type: container
+        min-versions-to-keep: 1
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: ${{ env.TAGS }}
+
+    - name: Build and push multi-arch Docker image
+      id: push
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64,linux/arm64
+
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true
+        
+  start-service:
+  
+    runs-on: ubuntu-latest
+    needs: build-and-publish
+    
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      
     - name: Install SSH Key
       uses: shimataro/ssh-key-action@v2
       with:
@@ -66,15 +137,25 @@ jobs:
       env:
         SSH_USER: ${{ secrets.USERNAME }}
         SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-        SSH_HOST: ${{ secrets.HOST }}     
-      
-    - name: Deploy Gradle Artifacts
-      run: rsync -avz /home/runner/work/Radio/Radio/build/libs/ ${{ secrets.USERNAME }}@${{ secrets.HOST }}:/opt/dockerfiles/radio
+        SSH_HOST: ${{ secrets.HOST }}
 
-    - name: Sync Docker Configuration
-      run: rsync -avz --include="Dockerfile" --include="docker-compose.yaml" --exclude="*" . ${{ secrets.USERNAME }}@${{ secrets.HOST }}:/opt/dockerfiles/radio
-
-    - name: Rebuild container
+    - name: Set lowercase IMAGE_NAME
+      run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+        
+    - name: Deploy and Restart Container
       run: |
-          ssh staging docker compose -f /opt/dockerfiles/radio/docker-compose.yaml down
-          ssh staging docker compose -f /opt/dockerfiles/radio/docker-compose.yaml up -d
+        ssh staging "
+          echo '${{ secrets.GHCR_TOKEN }}' | docker login ghcr.io -u ${{ env.GHCR_USER }} --password-stdin &&
+
+          # Stop running container
+          docker compose -f ${REMOTE_PATH}/docker-compose.yaml down || true &&
+
+          # Pull latest image
+          docker pull ${REGISTRY}/${IMAGE_NAME}:${{ env.TAGS }} &&
+
+          # Remove unused old images
+          docker image prune -af &&
+
+          # Start new container
+          docker compose -f ${REMOTE_PATH}/docker-compose.yaml up -d
+        "

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -5,9 +5,9 @@ name: Build and Deploy to Staging server
 
 on:
   push:
-    branches: [ ghcr-test ]
+    branches: [ master ]
   pull_request:
-    branches: [ ghcr-test ]
+    branches: [ master ]
 
 
 env:

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -71,6 +71,7 @@ jobs:
 
     - name: Cleanup old latest images in GHCR
       uses: actions/delete-package-versions@v5
+      continue-on-error: true
       with:
         package-name: radio
         package-type: container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazoncorretto:21
 
 RUN mkdir /bot
-COPY radio-1.0-SNAPSHOT.jar /bot
+COPY build/libs/radio-1.0-SNAPSHOT.jar /bot
 
 ENTRYPOINT ["java", "-jar", "/bot/radio-1.0-SNAPSHOT.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     api libs.dev.lavalink.youtube.common
 }
 
-group = 'de.splayfer'
+group = 'de.splayfunityde'
 version = '1.0-SNAPSHOT'
 description = 'radio'
 java.sourceCompatibility = JavaVersion.VERSION_21

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,6 @@
 services:
   radio:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/splayfunityde/radio:latest
     restart: always
     volumes:
       - /opt/dockerfiles/radio:/bot


### PR DESCRIPTION
Changed the deployment action/workflow:
- a production-ready docker image is now uploaded to ghcr instead of manual deployment via rsync
- `docker-compose.yaml` has been updated
- ghcr artefact attestation is impelmented

The hosting system now just needs to run `docker-compose.yaml` in `/opt/dockerfiles/radio` and needs to provide a `.env` file.